### PR TITLE
transformations with parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.4",
         "dashifen/exception": "^1.2"
     }
 }

--- a/src/AbstractTransformer.php
+++ b/src/AbstractTransformer.php
@@ -4,6 +4,22 @@ namespace Dashifen\Transformer;
 
 abstract class AbstractTransformer implements TransformerInterface
 {
+  protected bool $throw = false;
+  
+  /**
+   * setThrow
+   *
+   * Sets the throw property.
+   *
+   * @param bool $throw
+   *
+   * @return void
+   */
+  public function setThrow(bool $throw): void
+  {
+    $this->throw = $throw;
+  }
+  
   /**
    * canTransform
    *
@@ -17,7 +33,6 @@ abstract class AbstractTransformer implements TransformerInterface
   {
     return method_exists($this, $this->getTransformationMethod($field));
   }
-  
   
   /**
    * getTransformationMethod
@@ -38,12 +53,11 @@ abstract class AbstractTransformer implements TransformerInterface
    *
    * @param string $field
    * @param mixed  $value
-   * @param bool   $throw
    *
    * @return mixed
    * @throws TransformerException
    */
-  public function transform(string $field, $value, bool $throw = false)
+  public function transform(string $field, $value)
   {
     if ($this->canTransform($field)) {
       
@@ -63,7 +77,7 @@ abstract class AbstractTransformer implements TransformerInterface
     // field/value pair and only altering the ones for which we actually
     // have a transformation method.
     
-    if ($throw) {
+    if ($this->throw) {
       throw new TransformerException(
         sprintf('Cannot transform %s', $field),
         TransformerException::UNKNOWN_TRANSFORMATION
@@ -81,12 +95,11 @@ abstract class AbstractTransformer implements TransformerInterface
    *
    * @param string $field
    * @param array  $values
-   * @param bool   $throw
    *
    * @return array
    * @throws TransformerException
    */
-  public function transformArray(string $field, array $values, bool $throw = false): array
+  public function transformArray(string $field, array $values): array
   {
     
     // while it's likely that we're here because someone called the
@@ -99,7 +112,7 @@ abstract class AbstractTransformer implements TransformerInterface
       return array_map([$this, $this->getTransformationMethod($field)], $values);
     }
     
-    if ($throw) {
+    if ($this->throw) {
       throw new TransformerException(
         sprintf('Cannot transform %s', $field),
         TransformerException::UNKNOWN_TRANSFORMATION

--- a/src/AbstractTransformer.php
+++ b/src/AbstractTransformer.php
@@ -4,108 +4,108 @@ namespace Dashifen\Transformer;
 
 abstract class AbstractTransformer implements TransformerInterface
 {
-    /**
-     * canTransform
-     *
-     * Returns true if this object can transform data identified by the field
-     *
-     * @param string $field
-     *
-     * @return bool
-     */
-    public function canTransform (string $field): bool
-    {
-        return method_exists($this, $this->getTransformationMethod($field));
+  /**
+   * canTransform
+   *
+   * Returns true if this object can transform data identified by the field
+   *
+   * @param string $field
+   *
+   * @return bool
+   */
+  public function canTransform(string $field): bool
+  {
+    return method_exists($this, $this->getTransformationMethod($field));
+  }
+  
+  
+  /**
+   * getTransformationMethod
+   *
+   * Returns the name of a method in this class that is used to validate
+   * information labeled by $field.
+   *
+   * @param string $field
+   *
+   * @return string
+   */
+  abstract protected function getTransformationMethod(string $field): string;
+  
+  /**
+   * transform
+   *
+   * Passed the value through a transformation based on the field name.
+   *
+   * @param string $field
+   * @param mixed  $value
+   * @param bool   $throw
+   *
+   * @return mixed
+   * @throws TransformerException
+   */
+  public function transform(string $field, $value, bool $throw = false)
+  {
+    if ($this->canTransform($field)) {
+      
+      // if we can transform data that's labeled by our field, then we'll
+      // pass that value through the identified method.  if $value is an
+      // array, we can pass it over to the method below to transform each
+      // of its values.
+      
+      return !is_array($value)
+        ? $this->{$this->getTransformationMethod($field)}($value)
+        : $this->transformArray($field, $value);
     }
     
+    // otherwise, we return the original value unharmed or throw an
+    // exception based on the value of our $throw parameter.  by default,
+    // this allows us to call this method in a loop passing it each
+    // field/value pair and only altering the ones for which we actually
+    // have a transformation method.
     
-    /**
-     * getTransformationMethod
-     *
-     * Returns the name of a method in this class that is used to validate
-     * information labeled by $field.
-     *
-     * @param string $field
-     *
-     * @return string
-     */
-    abstract protected function getTransformationMethod (string $field): string;
-    
-    /**
-     * transform
-     *
-     * Passed the value through a transformation based on the field name.
-     *
-     * @param string $field
-     * @param mixed  $value
-     * @param bool   $throw
-     *
-     * @return mixed
-     * @throws TransformerException
-     */
-    public function transform (string $field, $value, bool $throw = false)
-    {
-        if ($this->canTransform($field)) {
-            
-            // if we can transform data that's labeled by our field, then we'll
-            // pass that value through the identified method.  if $value is an
-            // array, we can pass it over to the method below to transform each
-            // of its values.
-            
-            return !is_array($value)
-                ? $this->{$this->getTransformationMethod($field)}($value)
-                : $this->transformArray($field, $value);
-        }
-        
-        // otherwise, we return the original value unharmed or throw an
-        // exception based on the value of our $throw parameter.  by default,
-        // this allows us to call this method in a loop passing it each
-        // field/value pair and only altering the ones for which we actually
-        // have a transformation method.
-        
-        if ($throw) {
-            throw new TransformerException(
-                sprintf('Cannot transform %s', $field),
-                TransformerException::UNKNOWN_TRANSFORMATION
-            );
-        }
-        
-        return $value;
+    if ($throw) {
+      throw new TransformerException(
+        sprintf('Cannot transform %s', $field),
+        TransformerException::UNKNOWN_TRANSFORMATION
+      );
     }
     
-    /**
-     * transformArray
-     *
-     * Passes each value within an array through a transformation based on the
-     * field name.
-     *
-     * @param string $field
-     * @param array  $values
-     * @param bool   $throw
-     *
-     * @return array
-     * @throws TransformerException
-     */
-    public function transformArray (string $field, array $values, bool $throw = false): array
-    {
-        
-        // while it's likely that we're here because someone called the
-        // transform method above, we'll want to be sure to double-check that
-        // we can do so in case someone called this one directly.  then, if we
-        // can do so, we can use array_map to apply our transformation to each
-        // value within the array or the original values without alteration.
-        
-        if ($this->canTransform($field)){
-            return array_map([$this, $this->getTransformationMethod($field)], $values);
-        }
-        
-        if ($throw) {
-            throw new TransformerException(
-                sprintf('Cannot transform %s', $field),
-                TransformerException::UNKNOWN_TRANSFORMATION
-            );
-        }
-        
-        return $values;
+    return $value;
+  }
+  
+  /**
+   * transformArray
+   *
+   * Passes each value within an array through a transformation based on the
+   * field name.
+   *
+   * @param string $field
+   * @param array  $values
+   * @param bool   $throw
+   *
+   * @return array
+   * @throws TransformerException
+   */
+  public function transformArray(string $field, array $values, bool $throw = false): array
+  {
+    
+    // while it's likely that we're here because someone called the
+    // transform method above, we'll want to be sure to double-check that
+    // we can do so in case someone called this one directly.  then, if we
+    // can do so, we can use array_map to apply our transformation to each
+    // value within the array or the original values without alteration.
+    
+    if ($this->canTransform($field)) {
+      return array_map([$this, $this->getTransformationMethod($field)], $values);
     }
+    
+    if ($throw) {
+      throw new TransformerException(
+        sprintf('Cannot transform %s', $field),
+        TransformerException::UNKNOWN_TRANSFORMATION
+      );
+    }
+    
+    return $values;
+  }
 }

--- a/src/GeneralTransformer/AbstractGeneralTransformer.php
+++ b/src/GeneralTransformer/AbstractGeneralTransformer.php
@@ -55,11 +55,12 @@ abstract class AbstractGeneralTransformer implements GeneralTransformerInterface
    *
    * @param string $field
    * @param mixed  $value
+   * @param array  $parameters
    *
    * @return mixed
    * @throws TransformerException
    */
-  public function transform(string $field, $value)
+  public function transform(string $field, $value, ...$parameters)
   {
     if ($this->canTransform($field)) {
       
@@ -69,8 +70,8 @@ abstract class AbstractGeneralTransformer implements GeneralTransformerInterface
       // of its values.
       
       return !is_array($value)
-        ? $this->{$this->getTransformationMethod($field)}($value)
-        : $this->transformArray($field, $value);
+        ? $this->{$this->getTransformationMethod($field)}($value, ...$parameters)
+        : $this->transformArray($field, $value, ...$parameters);
     }
     
     // otherwise, we return the original value unharmed or throw an
@@ -97,13 +98,13 @@ abstract class AbstractGeneralTransformer implements GeneralTransformerInterface
    *
    * @param string $field
    * @param array  $values
+   * @param array  $parameters
    *
    * @return array
    * @throws TransformerException
    */
-  public function transformArray(string $field, array $values): array
+  public function transformArray(string $field, array $values, ...$parameters): array
   {
-    
     // while it's likely that we're here because someone called the
     // transform method above, we'll want to be sure to double-check that
     // we can do so in case someone called this one directly.  then, if we
@@ -111,7 +112,9 @@ abstract class AbstractGeneralTransformer implements GeneralTransformerInterface
     // value within the array or the original values without alteration.
     
     if ($this->canTransform($field)) {
-      return array_map([$this, $this->getTransformationMethod($field)], $values);
+      foreach ($values as &$value) {
+        $value = $this->{$this->getTransformationMethod($field)}($value, ...$parameters);
+      }
     }
     
     if ($this->throw) {

--- a/src/GeneralTransformer/AbstractGeneralTransformer.php
+++ b/src/GeneralTransformer/AbstractGeneralTransformer.php
@@ -1,8 +1,10 @@
 <?php
 
-namespace Dashifen\Transformer;
+namespace Dashifen\Transformer\GeneralTransformer;
 
-abstract class AbstractTransformer implements TransformerInterface
+use Dashifen\Transformer\TransformerException;
+
+abstract class AbstractGeneralTransformer implements GeneralTransformerInterface
 {
   protected bool $throw = false;
   

--- a/src/GeneralTransformer/GeneralTransformerInterface.php
+++ b/src/GeneralTransformer/GeneralTransformerInterface.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Dashifen\Transformer\GeneralTransformer;
+
+use Dashifen\Transformer\TransformerInterface;
+use Dashifen\Transformer\TransformerException;
+
+interface GeneralTransformerInterface extends TransformerInterface
+{
+  /**
+   * setThrow
+   *
+   * Sets the throw property.
+   *
+   * @param bool $throw
+   *
+   * @return void
+   */
+  public function setThrow(bool $throw): void;
+  
+  /**
+   * canTransform
+   *
+   * Returns true if this object can transform data identified by the field
+   *
+   * @param string $field
+   *
+   * @return bool
+   */
+  public function canTransform(string $field): bool;
+  
+  /**
+   * transform
+   *
+   * Passed the value through a transformation based on the field name.
+   *
+   * @param string $field
+   * @param mixed  $value
+   * @param array  $parameters
+   *
+   * @return mixed
+   * @throws TransformerException
+   */
+  public function transform(string $field, $value, ...$parameters);
+  
+  /**
+   * transformArray
+   *
+   * Passes each value within an array through a transformation based on the
+   * field name.
+   *
+   * @param string $field
+   * @param array  $values
+   * @param array  $parameters
+   *
+   * @return array
+   * @throws TransformerException
+   */
+  public function transformArray(string $field, array $values, ...$parameters): array;
+}

--- a/src/StorageTransformer/AbstractStorageTransformer.php
+++ b/src/StorageTransformer/AbstractStorageTransformer.php
@@ -94,11 +94,12 @@ abstract class AbstractStorageTransformer implements StorageTransformerInterface
    * @param string $field
    * @param mixed  $value
    * @param bool   $forStorage
+   * @param array  $parameters
    *
    * @return mixed
    * @throws TransformerException
    */
-  public function transform(string $field, $value, bool $forStorage = true)
+  public function transform(string $field, $value, bool $forStorage = true, ...$parameters)
   {
     if ($this->canTransform($field, $forStorage)) {
       
@@ -107,8 +108,8 @@ abstract class AbstractStorageTransformer implements StorageTransformerInterface
       // can pass it over to the method below to transform each of its values.
       
       return !is_array($value)
-        ? $this->{$this->getTransformationMethod($field, $forStorage)}($value)
-        : $this->transformArray($field, $value, $forStorage);
+        ? $this->{$this->getTransformationMethod($field, $forStorage)}($value, ...$parameters)
+        : $this->transformArray($field, $value, $forStorage, $parameters);
     }
     
     // otherwise, we return the original value unharmed or throw an
@@ -135,13 +136,14 @@ abstract class AbstractStorageTransformer implements StorageTransformerInterface
    *
    * @param string $field
    * @param        $value
+   * @param array  $parameters
    *
    * @return mixed
    * @throws TransformerException
    */
-  public function transformForStorage(string $field, $value)
+  public function transformForStorage(string $field, $value, ...$parameters)
   {
-    return $this->transform($field, $value);
+    return $this->transform($field, $value, ...$parameters);
   }
   
   /**
@@ -152,13 +154,14 @@ abstract class AbstractStorageTransformer implements StorageTransformerInterface
    *
    * @param string $field
    * @param        $value
+   * @param array  $parameters
    *
    * @return mixed
    * @throws TransformerException
    */
-  public function transformFromStorage(string $field, $value)
+  public function transformFromStorage(string $field, $value, ...$parameters)
   {
-    return $this->transform($field, $value, false);
+    return $this->transform($field, $value, false, ...$parameters);
   }
   
   /**
@@ -171,11 +174,12 @@ abstract class AbstractStorageTransformer implements StorageTransformerInterface
    * @param string $field
    * @param array  $values
    * @param bool   $forStorage
+   * @param array  $parameters
    *
    * @return array
    * @throws TransformerException
    */
-  public function transformArray(string $field, array $values, bool $forStorage = true): array
+  public function transformArray(string $field, array $values, bool $forStorage = true, ...$parameters): array
   {
     
     // while it's likely that we're here because someone called the
@@ -185,7 +189,9 @@ abstract class AbstractStorageTransformer implements StorageTransformerInterface
     // value within the array or the original values without alteration.
     
     if ($this->canTransform($field)) {
-      return array_map([$this, $this->getTransformationMethod($field, $forStorage)], $values);
+      foreach ($values as &$value) {
+        $value = $this->{$this->getTransformationMethod($field, $forStorage)}($value, ...$parameters);
+      }
     }
     
     if ($this->throw) {
@@ -206,13 +212,14 @@ abstract class AbstractStorageTransformer implements StorageTransformerInterface
    *
    * @param string $field
    * @param array  $values
+   * @param array  $parameters
    *
    * @return array
    * @throws TransformerException
    */
-  public function transformArrayForStorage(string $field, array $values): array
+  public function transformArrayForStorage(string $field, array $values, ...$parameters): array
   {
-    return $this->transformArray($field, $values);
+    return $this->transformArray($field, $values, ...$parameters);
   }
   
   /**
@@ -223,11 +230,12 @@ abstract class AbstractStorageTransformer implements StorageTransformerInterface
    *
    * @param string $field
    * @param array  $values
+   * @param array  $parameters
    *
    * @return array
    * @throws TransformerException
    */
-  public function transformArrayFromStorage(string $field, array $values): array
+  public function transformArrayFromStorage(string $field, array $values, ...$parameters): array
   {
     return $this->transformArray($field, $values, false);
   }

--- a/src/StorageTransformer/AbstractStorageTransformer.php
+++ b/src/StorageTransformer/AbstractStorageTransformer.php
@@ -6,6 +6,21 @@ use Dashifen\Transformer\TransformerException;
 
 abstract class AbstractStorageTransformer implements StorageTransformerInterface
 {
+  protected bool $throw = false;
+  
+  /**
+   * setThrow
+   *
+   * Sets the throw property.
+   *
+   * @param bool $throw
+   *
+   * @return void
+   */
+  public function setThrow(bool $throw): void
+  {
+    $this->throw = $throw;
+  }
   /**
    * canTransform
    *
@@ -35,7 +50,7 @@ abstract class AbstractStorageTransformer implements StorageTransformerInterface
    */
   public function canTransformForStorage(string $field): bool
   {
-    return $this->canTransform($field, true);
+    return $this->canTransform($field);
   }
   
   /**
@@ -79,12 +94,11 @@ abstract class AbstractStorageTransformer implements StorageTransformerInterface
    * @param string $field
    * @param mixed  $value
    * @param bool   $forStorage
-   * @param bool   $throw
    *
    * @return mixed
    * @throws TransformerException
    */
-  public function transform(string $field, $value, bool $forStorage = true, bool $throw = false)
+  public function transform(string $field, $value, bool $forStorage = true)
   {
     if ($this->canTransform($field, $forStorage)) {
       
@@ -103,7 +117,7 @@ abstract class AbstractStorageTransformer implements StorageTransformerInterface
     // field/value pair and only altering the ones for which we actually
     // have a transformation method.
     
-    if ($throw) {
+    if ($this->throw) {
       throw new TransformerException(
         sprintf('Cannot transform %s', $field),
         TransformerException::UNKNOWN_TRANSFORMATION
@@ -127,7 +141,7 @@ abstract class AbstractStorageTransformer implements StorageTransformerInterface
    */
   public function transformForStorage(string $field, $value)
   {
-    return $this->transform($field, $value, true);
+    return $this->transform($field, $value);
   }
   
   /**
@@ -157,12 +171,11 @@ abstract class AbstractStorageTransformer implements StorageTransformerInterface
    * @param string $field
    * @param array  $values
    * @param bool   $forStorage
-   * @param bool   $throw
    *
    * @return array
    * @throws TransformerException
    */
-  public function transformArray(string $field, array $values, bool $forStorage = true, bool $throw = false): array
+  public function transformArray(string $field, array $values, bool $forStorage = true): array
   {
     
     // while it's likely that we're here because someone called the
@@ -175,7 +188,7 @@ abstract class AbstractStorageTransformer implements StorageTransformerInterface
       return array_map([$this, $this->getTransformationMethod($field, $forStorage)], $values);
     }
     
-    if ($throw) {
+    if ($this->throw) {
       throw new TransformerException(
         sprintf('Cannot transform %s', $field),
         TransformerException::UNKNOWN_TRANSFORMATION
@@ -199,7 +212,7 @@ abstract class AbstractStorageTransformer implements StorageTransformerInterface
    */
   public function transformArrayForStorage(string $field, array $values): array
   {
-    return $this->transformArray($field, $values, true);
+    return $this->transformArray($field, $values);
   }
   
   /**

--- a/src/StorageTransformer/AbstractStorageTransformer.php
+++ b/src/StorageTransformer/AbstractStorageTransformer.php
@@ -6,216 +6,216 @@ use Dashifen\Transformer\TransformerException;
 
 abstract class AbstractStorageTransformer implements StorageTransformerInterface
 {
-    /**
-     * canTransform
-     *
-     * Returns true if this object can transform data identified by the field
-     * label based on the "direction" it's going, i.e. toward storage or toward
-     * memory.
-     *
-     * @param string $field
-     * @param bool   $forStorage
-     *
-     * @return bool
-     */
-    public function canTransform (string $field, bool $forStorage = true): bool
-    {
-        return method_exists($this, $this->getTransformationMethod($field, $forStorage));
+  /**
+   * canTransform
+   *
+   * Returns true if this object can transform data identified by the field
+   * label based on the "direction" it's going, i.e. toward storage or toward
+   * memory.
+   *
+   * @param string $field
+   * @param bool   $forStorage
+   *
+   * @return bool
+   */
+  public function canTransform(string $field, bool $forStorage = true): bool
+  {
+    return method_exists($this, $this->getTransformationMethod($field, $forStorage));
+  }
+  
+  /**
+   * canTransformForStorage
+   *
+   * This is a convenience method that calls canTransform passing a set flag
+   * for the $forStorage argument.
+   *
+   * @param string $field
+   *
+   * @return bool
+   */
+  public function canTransformForStorage(string $field): bool
+  {
+    return $this->canTransform($field, true);
+  }
+  
+  /**
+   * canTransformFromStorage
+   *
+   * This is a convenience method that calls canTransform passing an unset flag
+   * for the $forStorage argument.
+   *
+   * @param string $field
+   *
+   * @return bool
+   */
+  public function canTransformFromStorage(string $field): bool
+  {
+    return $this->canTransform($field, false);
+  }
+  
+  
+  /**
+   * getTransformationMethod
+   *
+   * Returns the name of a method in this class that is used to validate
+   * information labeled by $field.  The "for storage" flag may alter the
+   * name of this method based on whether we're transforming our value so
+   * that it can be stored or after it's been retrieved from storage.
+   *
+   * @param string $field
+   * @param bool   $forStorage
+   *
+   * @return string
+   */
+  abstract protected function getTransformationMethod(string $field, bool $forStorage): string;
+  
+  /**
+   * transform
+   *
+   * Passed the value through a transformation based on the field name.  This
+   * transformation may be different based on whether we're transforming the
+   * value for storage or retrieving it from storage.
+   *
+   * @param string $field
+   * @param mixed  $value
+   * @param bool   $forStorage
+   * @param bool   $throw
+   *
+   * @return mixed
+   * @throws TransformerException
+   */
+  public function transform(string $field, $value, bool $forStorage = true, bool $throw = false)
+  {
+    if ($this->canTransform($field, $forStorage)) {
+      
+      // if we can transform data that's labeled by our field, then we'll pass
+      // that value through the identified method.  if $value is an array, we
+      // can pass it over to the method below to transform each of its values.
+      
+      return !is_array($value)
+        ? $this->{$this->getTransformationMethod($field, $forStorage)}($value)
+        : $this->transformArray($field, $value, $forStorage);
     }
     
-    /**
-     * canTransformForStorage
-     *
-     * This is a convenience method that calls canTransform passing a set flag
-     * for the $forStorage argument.
-     *
-     * @param string $field
-     *
-     * @return bool
-     */
-    public function canTransformForStorage (string $field): bool
-    {
-        return $this->canTransform($field, true);
+    // otherwise, we return the original value unharmed or throw an
+    // exception based on the value of our $throw parameter.  by default,
+    // this allows us to call this method in a loop passing it each
+    // field/value pair and only altering the ones for which we actually
+    // have a transformation method.
+    
+    if ($throw) {
+      throw new TransformerException(
+        sprintf('Cannot transform %s', $field),
+        TransformerException::UNKNOWN_TRANSFORMATION
+      );
     }
     
-    /**
-     * canTransformFromStorage
-     *
-     * This is a convenience method that calls canTransform passing an unset flag
-     * for the $forStorage argument.
-     *
-     * @param string $field
-     *
-     * @return bool
-     */
-    public function canTransformFromStorage (string $field): bool
-    {
-        return $this->canTransform($field, false);
+    return $value;
+  }
+  
+  /**
+   * transformForStorage
+   *
+   * This is a convenience method that calls the transform() method passing a
+   * set flag for the $forStorage argument.
+   *
+   * @param string $field
+   * @param        $value
+   *
+   * @return mixed
+   * @throws TransformerException
+   */
+  public function transformForStorage(string $field, $value)
+  {
+    return $this->transform($field, $value, true);
+  }
+  
+  /**
+   * transformFromStorage
+   *
+   * This is a convenience method that calls the transform() method passing an
+   * unset flag for the $forStorage argument.
+   *
+   * @param string $field
+   * @param        $value
+   *
+   * @return mixed
+   * @throws TransformerException
+   */
+  public function transformFromStorage(string $field, $value)
+  {
+    return $this->transform($field, $value, false);
+  }
+  
+  /**
+   * transformArray
+   *
+   * Passes each value within an array through a transformation based on the
+   * field name and whether we're transforming our value for storage or
+   * retrieving it from storage.
+   *
+   * @param string $field
+   * @param array  $values
+   * @param bool   $forStorage
+   * @param bool   $throw
+   *
+   * @return array
+   * @throws TransformerException
+   */
+  public function transformArray(string $field, array $values, bool $forStorage = true, bool $throw = false): array
+  {
+    
+    // while it's likely that we're here because someone called the
+    // transform method above, we'll want to be sure to double-check that
+    // we can do so in case someone called this one directly.  then, if we
+    // can do so, we can use array_map to apply our transformation to each
+    // value within the array or the original values without alteration.
+    
+    if ($this->canTransform($field)) {
+      return array_map([$this, $this->getTransformationMethod($field, $forStorage)], $values);
     }
     
-    
-    /**
-     * getTransformationMethod
-     *
-     * Returns the name of a method in this class that is used to validate
-     * information labeled by $field.  The "for storage" flag may alter the
-     * name of this method based on whether we're transforming our value so
-     * that it can be stored or after it's been retrieved from storage.
-     *
-     * @param string $field
-     * @param bool   $forStorage
-     *
-     * @return string
-     */
-    abstract protected function getTransformationMethod (string $field, bool $forStorage): string;
-    
-    /**
-     * transform
-     *
-     * Passed the value through a transformation based on the field name.  This
-     * transformation may be different based on whether we're transforming the
-     * value for storage or retrieving it from storage.
-     *
-     * @param string $field
-     * @param mixed  $value
-     * @param bool   $forStorage
-     * @param bool   $throw
-     *
-     * @return mixed
-     * @throws TransformerException
-     */
-    public function transform (string $field, $value, bool $forStorage = true, bool $throw = false)
-    {
-        if ($this->canTransform($field, $forStorage)) {
-            
-            // if we can transform data that's labeled by our field, then we'll pass
-            // that value through the identified method.  if $value is an array, we
-            // can pass it over to the method below to transform each of its values.
-            
-            return !is_array($value)
-                ? $this->{$this->getTransformationMethod($field, $forStorage)}($value)
-                : $this->transformArray($field, $value, $forStorage);
-        }
-    
-        // otherwise, we return the original value unharmed or throw an
-        // exception based on the value of our $throw parameter.  by default,
-        // this allows us to call this method in a loop passing it each
-        // field/value pair and only altering the ones for which we actually
-        // have a transformation method.
-    
-        if ($throw) {
-            throw new TransformerException(
-                sprintf('Cannot transform %s', $field),
-                TransformerException::UNKNOWN_TRANSFORMATION
-            );
-        }
-    
-        return $value;
+    if ($throw) {
+      throw new TransformerException(
+        sprintf('Cannot transform %s', $field),
+        TransformerException::UNKNOWN_TRANSFORMATION
+      );
     }
     
-    /**
-     * transformForStorage
-     *
-     * This is a convenience method that calls the transform() method passing a
-     * set flag for the $forStorage argument.
-     *
-     * @param string $field
-     * @param        $value
-     *
-     * @return mixed
-     * @throws TransformerException
-     */
-    public function transformForStorage (string $field, $value)
-    {
-        return $this->transform($field, $value, true);
-    }
-    
-    /**
-     * transformFromStorage
-     *
-     * This is a convenience method that calls the transform() method passing an
-     * unset flag for the $forStorage argument.
-     *
-     * @param string $field
-     * @param        $value
-     *
-     * @return mixed
-     * @throws TransformerException
-     */
-    public function transformFromStorage (string $field, $value)
-    {
-        return $this->transform($field, $value, false);
-    }
-    
-    /**
-     * transformArray
-     *
-     * Passes each value within an array through a transformation based on the
-     * field name and whether we're transforming our value for storage or
-     * retrieving it from storage.
-     *
-     * @param string $field
-     * @param array  $values
-     * @param bool   $forStorage
-     * @param bool   $throw
-     *
-     * @return array
-     * @throws TransformerException
-     */
-    public function transformArray (string $field, array $values, bool $forStorage = true, bool $throw = false): array
-    {
-        
-        // while it's likely that we're here because someone called the
-        // transform method above, we'll want to be sure to double-check that
-        // we can do so in case someone called this one directly.  then, if we
-        // can do so, we can use array_map to apply our transformation to each
-        // value within the array or the original values without alteration.
-        
-        if ($this->canTransform($field)) {
-            return array_map([$this, $this->getTransformationMethod($field, $forStorage)], $values);
-        }
-    
-        if ($throw) {
-            throw new TransformerException(
-                sprintf('Cannot transform %s', $field),
-                TransformerException::UNKNOWN_TRANSFORMATION
-            );
-        }
-    
-        return $values;
-    }
-    
-    /**
-     * transformArrayForStorage
-     *
-     * This is a convenience method that calls the transformArray() method
-     * passing a set flag for the $forStorage argument.
-     *
-     * @param string $field
-     * @param array  $values
-     *
-     * @return array
-     * @throws TransformerException
-     */
-    public function transformArrayForStorage (string $field, array $values): array
-    {
-        return $this->transformArray($field, $values, true);
-    }
-    
-    /**
-     * transformArrayFromStorage
-     *
-     * This is a convenience method that calls the transformArray() method
-     * passing an unset flag for the $forStorage argument.
-     *
-     * @param string $field
-     * @param array  $values
-     *
-     * @return array
-     * @throws TransformerException
-     */
-    public function transformArrayFromStorage (string $field, array $values): array
-    {
-        return $this->transformArray($field, $values, false);
-    }
+    return $values;
+  }
+  
+  /**
+   * transformArrayForStorage
+   *
+   * This is a convenience method that calls the transformArray() method
+   * passing a set flag for the $forStorage argument.
+   *
+   * @param string $field
+   * @param array  $values
+   *
+   * @return array
+   * @throws TransformerException
+   */
+  public function transformArrayForStorage(string $field, array $values): array
+  {
+    return $this->transformArray($field, $values, true);
+  }
+  
+  /**
+   * transformArrayFromStorage
+   *
+   * This is a convenience method that calls the transformArray() method
+   * passing an unset flag for the $forStorage argument.
+   *
+   * @param string $field
+   * @param array  $values
+   *
+   * @return array
+   * @throws TransformerException
+   */
+  public function transformArrayFromStorage(string $field, array $values): array
+  {
+    return $this->transformArray($field, $values, false);
+  }
 }

--- a/src/StorageTransformer/StorageTransformerInterface.php
+++ b/src/StorageTransformer/StorageTransformerInterface.php
@@ -7,131 +7,131 @@ use Dashifen\Transformer\TransformerException;
 
 interface StorageTransformerInterface extends TransformerInterface
 {
-    /**
-     * canTransform
-     *
-     * Returns true if this object can transform data identified by the field
-     * label based on the "direction" it's going, i.e. toward storage or toward
-     * memory.
-     *
-     * @param string $field
-     * @param bool   $forStorage
-     *
-     * @return bool
-     */
-    public function canTransform (string $field, bool $forStorage = true): bool;
-    
-    /**
-     * canTransformForStorage
-     *
-     * This is a convenience method that calls canTransform passing a set flag
-     * for the $forStorage argument.
-     *
-     * @param string $field
-     *
-     * @return bool
-     */
-    public function canTransformForStorage (string $field): bool;
-    
-    /**
-     * canTransformFromStorage
-     *
-     * This is a convenience method that calls canTransform passing an unset
-     * flag for the $forStorage argument.
-     *
-     * @param string $field
-     *
-     * @return bool
-     */
-    public function canTransformFromStorage (string $field): bool;
-    
-    /**
-     * transform
-     *
-     * Passed the value through a transformation based on the field name.  This
-     * transformation may be different based on whether we're transforming the
-     * value for storage or retrieving it from storage.
-     *
-     * @param string $field
-     * @param mixed  $value
-     * @param bool   $forStorage
-     * @param bool   $throw
-     *
-     * @return mixed
-     * @throws TransformerException
-     */
-    public function transform (string $field, $value, bool $forStorage = true, bool $throw = false);
-    
-    /**
-     * transformForStorage
-     *
-     * This is a convenience method that calls the transform() method passing a
-     * set flag for the $forStorage argument.
-     *
-     * @param string $field
-     * @param        $value
-     *
-     * @return mixed
-     * @throws TransformerException
-     */
-    public function transformForStorage (string $field, $value);
-    
-    /**
-     * transformFromStorage
-     *
-     * This is a convenience method that calls the transform() method passing
-     * an unset flag for the $forStorage argument.
-     *
-     * @param string $field
-     * @param        $value
-     *
-     * @return mixed
-     * @throws TransformerException
-     */
-    public function transformFromStorage (string $field, $value);
-    
-    /**
-     * transformArray
-     *
-     * Passes each value within an array through a transformation based on the
-     * field name and whether we're transforming our value for storage or
-     * retrieving it from storage.
-     *
-     * @param string $field
-     * @param array  $values
-     * @param bool   $forStorage
-     * @param bool   $throw
-     *
-     * @return array
-     * @throws TransformerException
-     */
-    public function transformArray (string $field, array $values, bool $forStorage = true, bool $throw = false): array;
-    
-    /**
-     * transformArrayForStorage
-     *
-     * This is a convenience method that calls the transformArray() method
-     * passing a set flag for the $forStorage argument.
-     *
-     * @param string $field
-     * @param array  $values
-     *
-     * @return array
-     * @throws TransformerException
-     */
-    public function transformArrayForStorage (string $field, array $values): array;
-    
-    /**
-     * transformArrayFromStorage
-     *
-     * This is a convenience method that calls the transformArray() method
-     * passing an unset flag for the $forStorage argument.
-     *
-     * @param string $field
-     * @param array  $values
-     *
-     * @return array
-     * @throws TransformerException
-     */
-    public function transformArrayFromStorage (string $field, array $values): array;
+  /**
+   * canTransform
+   *
+   * Returns true if this object can transform data identified by the field
+   * label based on the "direction" it's going, i.e. toward storage or toward
+   * memory.
+   *
+   * @param string $field
+   * @param bool   $forStorage
+   *
+   * @return bool
+   */
+  public function canTransform(string $field, bool $forStorage = true): bool;
+  
+  /**
+   * canTransformForStorage
+   *
+   * This is a convenience method that calls canTransform passing a set flag
+   * for the $forStorage argument.
+   *
+   * @param string $field
+   *
+   * @return bool
+   */
+  public function canTransformForStorage(string $field): bool;
+  
+  /**
+   * canTransformFromStorage
+   *
+   * This is a convenience method that calls canTransform passing an unset
+   * flag for the $forStorage argument.
+   *
+   * @param string $field
+   *
+   * @return bool
+   */
+  public function canTransformFromStorage(string $field): bool;
+  
+  /**
+   * transform
+   *
+   * Passed the value through a transformation based on the field name.  This
+   * transformation may be different based on whether we're transforming the
+   * value for storage or retrieving it from storage.
+   *
+   * @param string $field
+   * @param mixed  $value
+   * @param bool   $forStorage
+   * @param bool   $throw
+   *
+   * @return mixed
+   * @throws TransformerException
+   */
+  public function transform(string $field, $value, bool $forStorage = true, bool $throw = false);
+  
+  /**
+   * transformForStorage
+   *
+   * This is a convenience method that calls the transform() method passing a
+   * set flag for the $forStorage argument.
+   *
+   * @param string $field
+   * @param        $value
+   *
+   * @return mixed
+   * @throws TransformerException
+   */
+  public function transformForStorage(string $field, $value);
+  
+  /**
+   * transformFromStorage
+   *
+   * This is a convenience method that calls the transform() method passing
+   * an unset flag for the $forStorage argument.
+   *
+   * @param string $field
+   * @param        $value
+   *
+   * @return mixed
+   * @throws TransformerException
+   */
+  public function transformFromStorage(string $field, $value);
+  
+  /**
+   * transformArray
+   *
+   * Passes each value within an array through a transformation based on the
+   * field name and whether we're transforming our value for storage or
+   * retrieving it from storage.
+   *
+   * @param string $field
+   * @param array  $values
+   * @param bool   $forStorage
+   * @param bool   $throw
+   *
+   * @return array
+   * @throws TransformerException
+   */
+  public function transformArray(string $field, array $values, bool $forStorage = true, bool $throw = false): array;
+  
+  /**
+   * transformArrayForStorage
+   *
+   * This is a convenience method that calls the transformArray() method
+   * passing a set flag for the $forStorage argument.
+   *
+   * @param string $field
+   * @param array  $values
+   *
+   * @return array
+   * @throws TransformerException
+   */
+  public function transformArrayForStorage(string $field, array $values): array;
+  
+  /**
+   * transformArrayFromStorage
+   *
+   * This is a convenience method that calls the transformArray() method
+   * passing an unset flag for the $forStorage argument.
+   *
+   * @param string $field
+   * @param array  $values
+   *
+   * @return array
+   * @throws TransformerException
+   */
+  public function transformArrayFromStorage(string $field, array $values): array;
 }

--- a/src/StorageTransformer/StorageTransformerInterface.php
+++ b/src/StorageTransformer/StorageTransformerInterface.php
@@ -55,12 +55,11 @@ interface StorageTransformerInterface extends TransformerInterface
    * @param string $field
    * @param mixed  $value
    * @param bool   $forStorage
-   * @param bool   $throw
    *
    * @return mixed
    * @throws TransformerException
    */
-  public function transform(string $field, $value, bool $forStorage = true, bool $throw = false);
+  public function transform(string $field, $value, bool $forStorage = true);
   
   /**
    * transformForStorage
@@ -100,12 +99,11 @@ interface StorageTransformerInterface extends TransformerInterface
    * @param string $field
    * @param array  $values
    * @param bool   $forStorage
-   * @param bool   $throw
    *
    * @return array
    * @throws TransformerException
    */
-  public function transformArray(string $field, array $values, bool $forStorage = true, bool $throw = false): array;
+  public function transformArray(string $field, array $values, bool $forStorage = true): array;
   
   /**
    * transformArrayForStorage

--- a/src/StorageTransformer/StorageTransformerInterface.php
+++ b/src/StorageTransformer/StorageTransformerInterface.php
@@ -2,8 +2,8 @@
 
 namespace Dashifen\Transformer\StorageTransformer;
 
-use Dashifen\Transformer\TransformerInterface;
 use Dashifen\Transformer\TransformerException;
+use Dashifen\Transformer\TransformerInterface;
 
 interface StorageTransformerInterface extends TransformerInterface
 {
@@ -55,11 +55,12 @@ interface StorageTransformerInterface extends TransformerInterface
    * @param string $field
    * @param mixed  $value
    * @param bool   $forStorage
+   * @param array  $parameters
    *
    * @return mixed
    * @throws TransformerException
    */
-  public function transform(string $field, $value, bool $forStorage = true);
+  public function transform(string $field, $value, bool $forStorage = true, ...$parameters);
   
   /**
    * transformForStorage
@@ -69,11 +70,12 @@ interface StorageTransformerInterface extends TransformerInterface
    *
    * @param string $field
    * @param        $value
+   * @param array  $parameters
    *
    * @return mixed
    * @throws TransformerException
    */
-  public function transformForStorage(string $field, $value);
+  public function transformForStorage(string $field, $value, ...$parameters);
   
   /**
    * transformFromStorage
@@ -83,11 +85,12 @@ interface StorageTransformerInterface extends TransformerInterface
    *
    * @param string $field
    * @param        $value
+   * @param array  $parameters
    *
    * @return mixed
    * @throws TransformerException
    */
-  public function transformFromStorage(string $field, $value);
+  public function transformFromStorage(string $field, $value, ...$parameters);
   
   /**
    * transformArray
@@ -99,11 +102,12 @@ interface StorageTransformerInterface extends TransformerInterface
    * @param string $field
    * @param array  $values
    * @param bool   $forStorage
+   * @param array  $parameters
    *
    * @return array
    * @throws TransformerException
    */
-  public function transformArray(string $field, array $values, bool $forStorage = true): array;
+  public function transformArray(string $field, array $values, bool $forStorage = true, ...$parameters): array;
   
   /**
    * transformArrayForStorage
@@ -113,11 +117,12 @@ interface StorageTransformerInterface extends TransformerInterface
    *
    * @param string $field
    * @param array  $values
+   * @param array  $parameters
    *
    * @return array
    * @throws TransformerException
    */
-  public function transformArrayForStorage(string $field, array $values): array;
+  public function transformArrayForStorage(string $field, array $values, ...$parameters): array;
   
   /**
    * transformArrayFromStorage
@@ -127,9 +132,10 @@ interface StorageTransformerInterface extends TransformerInterface
    *
    * @param string $field
    * @param array  $values
+   * @param array  $parameters
    *
    * @return array
    * @throws TransformerException
    */
-  public function transformArrayFromStorage(string $field, array $values): array;
+  public function transformArrayFromStorage(string $field, array $values, ...$parameters): array;
 }

--- a/src/TransformerException.php
+++ b/src/TransformerException.php
@@ -6,5 +6,5 @@ use Dashifen\Exception\Exception;
 
 class TransformerException extends Exception
 {
-    public const UNKNOWN_TRANSFORMATION = 1;
+  public const UNKNOWN_TRANSFORMATION = 1;
 }

--- a/src/TransformerInterface.php
+++ b/src/TransformerInterface.php
@@ -4,43 +4,43 @@ namespace Dashifen\Transformer;
 
 interface TransformerInterface
 {
-    /**
-     * canTransform
-     *
-     * Returns true if this object can transform data identified by the field
-     *
-     * @param string $field
-     *
-     * @return bool
-     */
-    public function canTransform (string $field): bool;
-    
-    /**
-     * transform
-     *
-     * Passed the value through a transformation based on the field name.
-     *
-     * @param string $field
-     * @param mixed  $value
-     * @param bool   $throw
-     *
-     * @return mixed
-     * @throws TransformerException
-     */
-    public function transform (string $field, $value, bool $throw = false);
-    
-    /**
-     * transformArray
-     *
-     * Passes each value within an array through a transformation based on the
-     * field name.
-     *
-     * @param string $field
-     * @param array  $values
-     * @param bool   $throw
-     *
-     * @return array
-     * @throws TransformerException
-     */
-    public function transformArray (string $field, array $values, bool $throw = false): array;
+  /**
+   * canTransform
+   *
+   * Returns true if this object can transform data identified by the field
+   *
+   * @param string $field
+   *
+   * @return bool
+   */
+  public function canTransform(string $field): bool;
+  
+  /**
+   * transform
+   *
+   * Passed the value through a transformation based on the field name.
+   *
+   * @param string $field
+   * @param mixed  $value
+   * @param bool   $throw
+   *
+   * @return mixed
+   * @throws TransformerException
+   */
+  public function transform(string $field, $value, bool $throw = false);
+  
+  /**
+   * transformArray
+   *
+   * Passes each value within an array through a transformation based on the
+   * field name.
+   *
+   * @param string $field
+   * @param array  $values
+   * @param bool   $throw
+   *
+   * @return array
+   * @throws TransformerException
+   */
+  public function transformArray(string $field, array $values, bool $throw = false): array;
 }

--- a/src/TransformerInterface.php
+++ b/src/TransformerInterface.php
@@ -4,52 +4,7 @@ namespace Dashifen\Transformer;
 
 interface TransformerInterface
 {
-  /**
-   * setThrow
-   *
-   * Sets the throw property.
-   *
-   * @param bool $throw
-   *
-   * @return void
-   */
-  public function setThrow(bool $throw): void;
-  
-  /**
-   * canTransform
-   *
-   * Returns true if this object can transform data identified by the field
-   *
-   * @param string $field
-   *
-   * @return bool
-   */
-  public function canTransform(string $field): bool;
-  
-  /**
-   * transform
-   *
-   * Passed the value through a transformation based on the field name.
-   *
-   * @param string $field
-   * @param mixed  $value
-   *
-   * @return mixed
-   * @throws TransformerException
-   */
-  public function transform(string $field, $value);
-  
-  /**
-   * transformArray
-   *
-   * Passes each value within an array through a transformation based on the
-   * field name.
-   *
-   * @param string $field
-   * @param array  $values
-   *
-   * @return array
-   * @throws TransformerException
-   */
-  public function transformArray(string $field, array $values): array;
+  // this is an empty interface that both the GeneralTransformerInterface and
+  // the StorageTransformerInterface can extend. that allows all of the objects
+  // herein to be identified as an instance of TransformerInterface.
 }

--- a/src/TransformerInterface.php
+++ b/src/TransformerInterface.php
@@ -5,6 +5,17 @@ namespace Dashifen\Transformer;
 interface TransformerInterface
 {
   /**
+   * setThrow
+   *
+   * Sets the throw property.
+   *
+   * @param bool $throw
+   *
+   * @return void
+   */
+  public function setThrow(bool $throw): void;
+  
+  /**
    * canTransform
    *
    * Returns true if this object can transform data identified by the field
@@ -22,12 +33,11 @@ interface TransformerInterface
    *
    * @param string $field
    * @param mixed  $value
-   * @param bool   $throw
    *
    * @return mixed
    * @throws TransformerException
    */
-  public function transform(string $field, $value, bool $throw = false);
+  public function transform(string $field, $value);
   
   /**
    * transformArray
@@ -37,10 +47,9 @@ interface TransformerInterface
    *
    * @param string $field
    * @param array  $values
-   * @param bool   $throw
    *
    * @return array
    * @throws TransformerException
    */
-  public function transformArray(string $field, array $values, bool $throw = false): array;
+  public function transformArray(string $field, array $values): array;
 }


### PR DESCRIPTION
the 2.0 release branch of the transformer receives a value, does something to it, and then returns the modified value.  there's no context or additional information available to the transformation routine.  

but, sometimes, to perform the transformation, the transformer might need to know more information about the state of things.  consider a situation where a string like 50% is to be transformed to be 50% of a given total.  Without knowing the total, the transformation can't actually produce the result.

these changes alter our objects to allow for additional parameters being sent to the `transform` and `transformArray` methods which are, in turn, provided to specific transformation routines.